### PR TITLE
Fix media_player.frontier_silicon dependencies to work out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache libstdc++ && \
 		gnupg \
 		libgcc \
 		linux-headers \
-		make 
+		make
 
 RUN apk --no-cache add python3-dev py-pip py3-netifaces
 
@@ -18,6 +18,10 @@ RUN apk --no-cache add python3-dev py-pip py3-netifaces
 RUN apk --no-cache add libffi-dev openssl-dev
 
 RUN pip3 --no-cache-dir install --upgrade pip
+
+# required for media_player.frontier_silicon
+RUN apk --no-cache add py-lxml
+RUN pip3 --no-cache-dir install afsapi
 
 RUN mkdir /config && \
 	pip3 --no-cache-dir install homeassistant


### PR DESCRIPTION
Add py-lxml for [afsapi](https://github.com/zhelev/python-afsapi) python package.
Install afsapi manually because home asisstant is otherwise unable to

> Unable to install package afsapi==0.0.3: Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-8q7rd67t/lxml/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-foj72ogc-record/install-record.txt --single-version-externally-managed --prefix  --compile --user --prefix=" failed with error code 1 in /tmp/pip-build-8q7rd67t/lxml/